### PR TITLE
Fix 5 critical bugs and F12 settings hotkey

### DIFF
--- a/slack-channel-summary.js
+++ b/slack-channel-summary.js
@@ -262,16 +262,18 @@
                 });
             });
 
-            // Close button
-            closeBtn.addEventListener('click', () => {
+            const closeWindow = () => {
                 summaryWindow.remove();
-            });
+                document.removeEventListener('keydown', escapeHandler);
+            };
+
+            // Close button
+            closeBtn.addEventListener('click', closeWindow);
 
             // Escape key to close
             const escapeHandler = (e) => {
                 if (e.key === 'Escape') {
-                    summaryWindow.remove();
-                    document.removeEventListener('keydown', escapeHandler);
+                    closeWindow();
                 }
             };
             document.addEventListener('keydown', escapeHandler);
@@ -279,7 +281,7 @@
             // Click outside to close
             summaryWindow.addEventListener('click', (e) => {
                 if (e.target === summaryWindow) {
-                    summaryWindow.remove();
+                    closeWindow();
                 }
             });
         },
@@ -520,11 +522,13 @@
                             utils.debug('🧵 No thread messages found in DOM');
                             textbox.value = `❌ Thread Summary Error\n\nNo thread messages found in DOM\n\nFalling back to channel summary...`;
                             // Continue with regular channel summary as fallback
+                            result = await this.getChannelSummaryMessages(timeRange);
                         }
                     } catch (error) {
                         utils.debug('🧵 Thread message extraction failed', { error: error.message });
                         textbox.value = `❌ Thread Summary Error\n\nFailed to extract thread messages: ${error.message}\n\nFalling back to channel summary...`;
                         // Continue with regular channel summary as fallback
+                        result = await this.getChannelSummaryMessages(timeRange);
                     }
                 } else {
                     utils.debug('📝 MAIN CHANNEL DETECTED - Continuing with regular summary');

--- a/slack-settings.js
+++ b/slack-settings.js
@@ -632,13 +632,18 @@
             currentSettings: SlackSettings.loadSettings()
         });
 
-        // Add keyboard shortcut for settings (F12)
+        // Expose for diagnostics / fallback invocation
+        window.SlackSettings = SlackSettings;
+
+        // Add keyboard shortcut for settings (F12) — capture phase so Slack/Electron
+        // can't swallow the event before us.
         document.addEventListener('keydown', function(event) {
             if (event.key === 'F12') {
                 event.preventDefault();
+                event.stopPropagation();
                 SlackSettings.showSettingsMenu();
             }
-        });
+        }, true);
     }
 
     // Wait for DOM to be ready

--- a/slack-text-improver.js
+++ b/slack-text-improver.js
@@ -100,7 +100,15 @@
 
             const savedSettings = localStorage.getItem('slackpolish_settings');
             if (savedSettings) {
-                const settings = JSON.parse(savedSettings);
+                let settings;
+                try {
+                    settings = JSON.parse(savedSettings);
+                } catch (parseErr) {
+                    utils.log(`⚠️ Corrupted slackpolish_settings in localStorage, clearing: ${parseErr.message}`);
+                    localStorage.removeItem('slackpolish_settings');
+                    settings = null;
+                }
+                if (settings) {
 
                 // Handle new settings structure from rich interface
                 if (settings.language) {
@@ -172,6 +180,7 @@
                     hasCustomInstructions: !!CONFIG.CUSTOM_INSTRUCTIONS,
                     hasApiKey: !!CONFIG.OPENAI_API_KEY
                 });
+                }
             }
         } catch (error) {
             utils.log(`Error loading settings: ${error.message}`);
@@ -2781,7 +2790,7 @@ IMPORTANT: Respond with ONLY the improved text. Do not include any explanations,
     // Show simple error notification
     function showSimpleError(message) {
         const errorDiv = document.createElement('div');
-        errorDiv.innerHTML = `❌ ${message}`;
+        errorDiv.textContent = `❌ ${message}`;
         errorDiv.style.cssText = `
             position: fixed;
             top: 20px;
@@ -2842,7 +2851,7 @@ IMPORTANT: Respond with ONLY the improved text. Do not include any explanations,
     // Show simple error notification (original design)
     function showSimpleError(message) {
         const errorDiv = document.createElement('div');
-        errorDiv.innerHTML = `❌ ${message}`;
+        errorDiv.textContent = `❌ ${message}`;
         errorDiv.style.cssText = `
             position: fixed;
             top: 20px;
@@ -3055,7 +3064,7 @@ IMPORTANT: Respond with ONLY the improved text. Do not include any explanations,
                             <div style="font-size: 13px; color: #666;">Please configure your OpenAI API key to continue</div>
                         </div>
                     </div>
-                    <p style="margin: 0 0 20px 0; color: #333; line-height: 1.4;">${message}</p>
+                    <p id="slackpolish-api-popup-message" style="margin: 0 0 20px 0; color: #333; line-height: 1.4;"></p>
 
                     <div style="margin-bottom: 20px;">
                         <label style="display: block; margin-bottom: 8px; font-weight: bold; color: #333;">Enter your OpenAI API Key:</label>
@@ -3074,6 +3083,12 @@ IMPORTANT: Respond with ONLY the improved text. Do not include any explanations,
         `;
 
         document.body.appendChild(popup);
+
+        // Set message via textContent to avoid HTML injection
+        const messageEl = popup.querySelector('#slackpolish-api-popup-message');
+        if (messageEl) {
+            messageEl.textContent = message;
+        }
 
         // Add logo to popup
         const logoContainer = document.getElementById('api-popup-logo');
@@ -4461,24 +4476,39 @@ IMPORTANT: Respond with ONLY the improved text. Do not include any explanations,
                     return;
                 }
 
-                content.innerHTML = this.logs.map(log => {
-                    const sourceColors = {
-                        'text-improver': '#2eb67d',
-                        'settings': '#e01e5a',
-                        'channel-summary': '#ecb22e',
-                        'default': '#2eb67d'
-                    };
+                const sourceColors = {
+                    'text-improver': '#2eb67d',
+                    'settings': '#e01e5a',
+                    'channel-summary': '#ecb22e',
+                    'default': '#2eb67d'
+                };
+
+                content.textContent = '';
+                this.logs.forEach(log => {
                     const sourceColor = sourceColors[log.source] || sourceColors.default;
 
-                    let html = `<div style="margin-bottom: 8px; padding: 6px; background: #252837; border-radius: 4px; border-left: 3px solid ${sourceColor};">`;
-                    html += `<div style="color: ${sourceColor}; font-size: 10px; margin-bottom: 4px;">[${log.timestamp}] ${log.source.toUpperCase()}</div>`;
-                    html += `<div style="color: #e8e8e8; margin-bottom: 4px;">${log.message}</div>`;
+                    const entry = document.createElement('div');
+                    entry.style.cssText = `margin-bottom: 8px; padding: 6px; background: #252837; border-radius: 4px; border-left: 3px solid ${sourceColor};`;
+
+                    const header = document.createElement('div');
+                    header.style.cssText = `color: ${sourceColor}; font-size: 10px; margin-bottom: 4px;`;
+                    header.textContent = `[${log.timestamp}] ${String(log.source).toUpperCase()}`;
+                    entry.appendChild(header);
+
+                    const messageEl = document.createElement('div');
+                    messageEl.style.cssText = 'color: #e8e8e8; margin-bottom: 4px;';
+                    messageEl.textContent = log.message != null ? String(log.message) : '';
+                    entry.appendChild(messageEl);
+
                     if (log.data) {
-                        html += `<div style="color: #a0a0a0; font-size: 10px; white-space: pre-wrap; background: #1a1d29; padding: 4px; border-radius: 2px; margin-top: 4px; max-height: 200px; overflow-y: auto;">${log.data}</div>`;
+                        const dataEl = document.createElement('div');
+                        dataEl.style.cssText = 'color: #a0a0a0; font-size: 10px; white-space: pre-wrap; background: #1a1d29; padding: 4px; border-radius: 2px; margin-top: 4px; max-height: 200px; overflow-y: auto;';
+                        dataEl.textContent = typeof log.data === 'string' ? log.data : String(log.data);
+                        entry.appendChild(dataEl);
                     }
-                    html += `</div>`;
-                    return html;
-                }).join('');
+
+                    content.appendChild(entry);
+                });
 
                 // Auto-scroll to bottom
                 content.scrollTop = content.scrollHeight;


### PR DESCRIPTION
## Summary

Five real defects surfaced from a focused read-through of `slack-text-improver.js` and `slack-channel-summary.js`, plus one fix discovered while verifying the install on macOS.

- **XSS via `innerHTML` in the debug log window** — `log.message` and `log.data` were string-interpolated into HTML and assigned via `innerHTML`. `log.data` includes API responses and draft text, so any HTML/JS in those payloads would execute in Slack's origin. Replaced the `.map(...).join('') + innerHTML` block with imperative `createElement` + `textContent` per row.
- **`result is undefined` crash on thread-summary fallback** — when the thread DOM extraction yielded no messages or threw, the code wrote an error to the textbox but never populated `result`, then dereferenced `result.channelName` and crashed. Both fallback branches now run the regular `getChannelSummaryMessages(timeRange)` path the comments already promised.
- **Unguarded `JSON.parse` of `slackpolish_settings`** — a corrupted localStorage entry would kill the entire injection. Wrapped in try/catch; on failure we log, clear the bad key, and continue with defaults.
- **Escape-handler leak when summary modal closed via X or outside-click** — the keydown listener was only removed when the user actually pressed Escape. Extracted a `closeWindow()` that calls `removeEventListener` and wired the X button, outside-click, and Escape paths to it.
- **XSS via `innerHTML` in error popups** — `showSimpleError` did `errorDiv.innerHTML = '❌ ${message}'`, and the API-key popup interpolated `${message}` into a larger HTML template. Switched the simple error path to `textContent`, and the API-key popup now embeds an empty placeholder `<p id="slackpolish-api-popup-message">` and assigns the message via `textContent` after insertion.
- **F12 settings hotkey reliably opens the menu** — discovered while smoke-testing the macOS install: Slack/Electron's own capture-phase handler was swallowing F12 before SlackPolish's bubble-phase listener saw it. Re-registered with `useCapture: true` and added `event.stopPropagation()`. Also exposed `window.SlackSettings` so the menu can be invoked from DevTools as a fallback.

## Why

The first four are stability/security defects with concrete repro paths (corrupted localStorage, thread fallback, repeated modal opens, attacker-controlled error/log strings). The fifth is the same XSS pattern in a different spot. The F12 fix unbreaks the primary way users access settings on macOS.

## Test plan

- [ ] Open the debug window, polish text containing `<img src=x onerror=alert(1)>`, confirm the payload renders as literal text.
- [ ] Open a thread, press F10 → trigger thread summary; with the fix, when DOM extraction misses it falls back to channel summary instead of throwing.
- [ ] In DevTools: `localStorage.setItem('slackpolish_settings', '{not json'); location.reload()` → confirm the extension still initializes and the bad key is cleared.
- [ ] Open the summary modal and close via X / outside-click repeatedly; confirm `getEventListeners(document).keydown` count does not grow.
- [ ] Force an API error whose message contains `<img src=x onerror=alert(1)>`; confirm the popup shows literal text, no execution.
- [ ] Press F12 in Slack on macOS; settings menu opens.
- [ ] Run `python3 test-with-settings.py` and `python3 test-with-channel-summary.py` for regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)